### PR TITLE
Add getters for ops contracts

### DIFF
--- a/contracts/Presales.sol
+++ b/contracts/Presales.sol
@@ -117,6 +117,20 @@ contract Presales is Owned {
 	}
 
     /**
+       @dev Returns addresses of accounts
+    */
+	function getAccounts() public view returns (address[]) {
+		return accounts;
+	}
+
+    /**
+       @dev Returns number of accounts
+    */
+	function getAccountsSize() public view returns (uint256) {
+		return accounts.length;
+	}
+
+    /**
        @dev Sets status to Locked so that no new presales can be added
     */
 	function lock() public onlyOwner onlyIfUnlocked returns (bool) {

--- a/contracts/ProcessableAllocations.sol
+++ b/contracts/ProcessableAllocations.sol
@@ -117,6 +117,20 @@ contract ProcessableAllocations is Owned {
 	}
 
     /**
+       @dev Returns addresses of grantees
+    */
+	function getGrantees() public view returns (address[]) {
+		return grantees;
+	}
+
+    /**
+       @dev Returns number of grantees
+    */
+	function getGranteesSize() public view returns (uint256) {
+		return grantees.length;
+	}
+
+    /**
        @dev Sets status to Locked so that no new processable allocations can be added
     */
 	function lock() public onlyOwner onlyIfUnlocked returns (bool) {

--- a/contracts/grantableAllocations.sol
+++ b/contracts/grantableAllocations.sol
@@ -116,6 +116,20 @@ contract GrantableAllocations is Owned {
 	}
 
     /**
+       @dev Returns addresses of grantees
+    */
+	function getGrantees() public view returns (address[]) {
+		return grantees;
+	}
+
+    /**
+       @dev Returns number of grantees
+    */
+	function getGranteesSize() public view returns (uint256) {
+		return grantees.length;
+	}
+
+    /**
        @dev Sets status to Locked so that no new grantable allocations can be added
     */
 	function lock() public onlyOwner onlyIfUnlocked returns (bool) {


### PR DESCRIPTION
Add additional getters for data in `Presales`, `GrantableAllocations`, and `ProcessableAllocations`.