### PR TITLE
contracts: make Owner transfership explicitly not ownerless [ch120]

### DIFF
--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -39,6 +39,8 @@ contract Owned {
 
 
     function initiateOwnershipTransfer(address _proposedOwner) public onlyOwner returns (bool) {
+        require(_proposedOwner != address(0));
+
         proposedOwner = _proposedOwner;
 
         OwnershipTransferInitiated(_proposedOwner);
@@ -55,6 +57,14 @@ contract Owned {
 
         OwnershipTransferCompleted(owner);
 
+        return true;
+    }
+
+
+    function cancelOwnershipTransfer() public onlyOwner returns (bool) {
+        if (proposedOwner == address(0)) return false;
+        
+        proposedOwner = address(0);
         return true;
     }
 }


### PR DESCRIPTION
For future use, improve Owned.sol to explicitly handle `address(0)`; to cover the case of cancelling an initialized ownership transfer, introduce a new function `cancelOwnershipTransfer`;

the behaviour is exactly as current implementation; so don't merge before unit tests are updated and included here too.